### PR TITLE
Fix for install in nonstandard location

### DIFF
--- a/sublautopep8.py
+++ b/sublautopep8.py
@@ -5,10 +5,10 @@ import tempfile
 import subprocess
 import os
 
+plugin_path = os.path.split(os.path.abspath(__file__))[0]
 
 class AutoPep8PreviewCommand(sublime_plugin.TextCommand):
     def run(self, edit):
-        plugin_path = os.path.join(sublime.packages_path(), "AutoPEP8")
         file_path = sublime.active_window().active_view().file_name()
         params = ["env", "python", "autopep8.py", file_path, "-d", "-vv"]
         settings = sublime.load_settings('AutoPep8.sublime-settings')
@@ -34,7 +34,6 @@ class AutoPep8PreviewCommand(sublime_plugin.TextCommand):
 class AutoPep8Command(sublime_plugin.TextCommand):
     def run(self, edit):
         encoding = sublime.active_window().active_view().encoding()
-        plugin_path = os.path.join(sublime.packages_path(), "AutoPEP8")
         fd, tmp_path = tempfile.mkstemp()
         data = self.view.substr(sublime.Region(0, self.view.size()))
         open(tmp_path, 'w').write(data.encode(encoding))


### PR DESCRIPTION
This PR fixes a few issues I had with sublimeautopep8 due to installing it in a nonstandard directory name and using a different python as my primary python binary.
