### PR TITLE
Update sublautopep8.py

### DIFF
--- a/sublautopep8.py
+++ b/sublautopep8.py
@@ -58,7 +58,9 @@ class AutoPep8(object):
         open(in_path, 'w').write(text.encode(encoding))
         self.format_file(in_path, out_path, preview, encoding)
         out_data = fd_out.read().decode(encoding)
+        os.close(fd1)
         os.remove(in_path)
+        os.close(fd2)
         os.remove(out_path)
         return out_data
 


### PR DESCRIPTION
I was getting errors while using  SublimeAutoPEP8:

```
"WindowsError: [Error 32] The process cannot access the file because it is being used by another process: <temp file path>"
```

A bit of research revealed similar problems with other Python projects:

http://stackoverflow.com/questions/1470350/why-is-the-windowserror-while-deleting-the-temporary-file

It seems the problem is removing the temp file which you still have an open handle to. I've applied these changes directly for my own Sublime Text install, and  SublimeAutoPEP8 now works for me.
