### PR TITLE
Added Python (Django) format to the syntax list

### DIFF
--- a/AutoPep8 (Windows).sublime-settings
+++ b/AutoPep8 (Windows).sublime-settings
@@ -21,7 +21,7 @@
     // Format/Preview menu items only appear for views
     // with syntax from `syntax_list`
     // value is base filename of the .tmLanguage syntax files
-    "syntax_list": ["Python"],
+    "syntax_list": ["Python", "Python (Django)"],
 
     "file_menu_search_depth": 3, // max depth to search python files
 

--- a/AutoPep8.sublime-settings
+++ b/AutoPep8.sublime-settings
@@ -21,7 +21,7 @@
     // Format/Preview menu items only appear for views
     // with syntax from `syntax_list`
     // value is base filename of the .tmLanguage syntax files
-    "syntax_list": ["Python"],
+    "syntax_list": ["Python", "Python (Django)"],
 
     "file_menu_search_depth": 3, // max depth to search python files
 


### PR DESCRIPTION
I added "Python (Django)" to the syntax list, otherwise working on Django projects is a pain because the syntax has to be changed for every file to have the PEP8 autocorrection.