### PR TITLE
Support use of pep8 config files.

### DIFF
--- a/AutoPep8.sublime-settings
+++ b/AutoPep8.sublime-settings
@@ -2,7 +2,7 @@
     "max-line-length": 79,
 
     // list codes for fixes; used by --ignore and --select
-    "list-fixes": "",
+    "list-fixes": false,
 
     // do not fix these errors / warnings(e.g. E4, W)
     "ignore": "E24, E226",
@@ -12,6 +12,12 @@
 
     // enable possibly unsafe changes (E711, E712)
     "aggressive": 0,
+
+    // allow autopep8 to use global config files for defaults
+    "apply-config": false,
+
+    // path to the global config file to use instead of the default
+    "global-config": null,
 
     // number of spaces per indent level
     "indent-size": 4,

--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,8 @@ Once you install Package Control, restart ST2/ST3 and bring up the Command Palet
 }
 ```
 
+Settings that are passed to autopep8 such as `ignore`, `select`, `max-line-length`, `indent-size` and `global-config` can be set to null to allow the defaults provided by a pep8 file, e.g. `~/.config/pep8` to be used instead.
+
 ## Using
 
 + **SideBar** - right click on the file(s) or folder(s)

--- a/sublautopep8.py
+++ b/sublautopep8.py
@@ -48,9 +48,10 @@ def _PrintDebugInfo():
         '\n\tconfig: %(config)s'
     )
     config_keys = (
-        'max-line-length', 'list-fixes', 'ignore', 'select', 'aggressive',
-        'indent-size', 'format_on_save', 'syntax_list',
-        'file_menu_search_depth', 'avoid_new_line_in_select_mode', 'debug',
+        'max-line-length', 'list-fixes', 'ignore', 'select', 'global-config',
+        'apply-config''aggressive', 'indent-size', 'format_on_save',
+        'syntax_list', 'file_menu_search_depth',
+        'avoid_new_line_in_select_mode', 'debug',
     )
     config = {}
     for key in config_keys:
@@ -93,8 +94,13 @@ def pep8_params():
     params = ['-d']  # args for preview
 
     # read settings
-    for opt in ("ignore", "select", "max-line-length", "indent-size"):
+    for opt in ("ignore", "select", "max-line-length", "indent-size",
+                "global-config"):
         opt_value = Settings(opt, "")
+        # skip any options that are defined as null, allows config file defaults
+        # to be used instead.
+        if opt_value is None:
+            continue
         # remove white spaces as autopep8 does not trim them
         if opt in ("ignore", "select"):
             opt_value = ','.join(param.strip()
@@ -114,7 +120,8 @@ def pep8_params():
     # autopep8.parse_args requirea at least one positional argument
     params.append('fake-file')
 
-    parsed_params = autopep8.parse_args(params)
+    parsed_params = autopep8.parse_args(
+        params, apply_config=Settings("apply-config", False))
     get_logger().debug('autopep8.params: %s', parsed_params)
     return parsed_params
 

--- a/sublautopep8.py
+++ b/sublautopep8.py
@@ -102,7 +102,7 @@ def pep8_params():
         params.append("--{0}={1}".format(opt, opt_value))
 
     if Settings("list-fixes", None):
-        params.append("--{0}={1}".format(opt, Settings(opt)))
+        params.append("--list-fixes")
 
     for opt in ("aggressive",):
         opt_count = Settings(opt, 0)


### PR DESCRIPTION

* Adds an `apply-config` setting to enable the use of global configs.
* Adds a `global-config` setting to allow specifying of custom global configs.
* Supports null in all pep8 passthrough settings to prevent overwriting of defaults from global configs.