### PR TITLE
Added Djaneiro Python syntax by default

### DIFF
--- a/AutoPep8.sublime-settings
+++ b/AutoPep8.sublime-settings
@@ -30,7 +30,7 @@
     // Format/Preview menu items only appear for views
     // with syntax from `syntax_list`
     // value is base filename of the .tmLanguage syntax files
-    "syntax_list": ["Python"],
+    "syntax_list": ["Python", "Python Django"],
 
     // The value shows how deep the plugin should look for *.py files
     // before disabling "Preview" and "Format" items in the Side Bar "AutoPep8" Context Menu.


### PR DESCRIPTION
Djaneiro sets its own syntax as Python default, effectively disabling AutoPEP8 unless built-in syntax is manually selected. This adds its syntax file to default settings, obviating the need to unpack Djaneiro's package and look for the syntax file's name.