### PR TITLE
Respect autopep8 config file locations

### DIFF
--- a/sublautopep8.py
+++ b/sublautopep8.py
@@ -124,8 +124,6 @@ def pep8_params():
         opt_value = user_settings.get(opt, '')
         if opt_value == '' or opt_value is None:
             continue
-        if opt_value and opt in ('exclude', 'global-config'):
-            opt_value = sublime.expand_variables(opt_value, env_vars)
 
         if opt in ('exclude', 'global-config'):
             if opt_value:


### PR DESCRIPTION
Fix for #67: searching for config files will happen in the same way as when passing files to autopep8.exe